### PR TITLE
make *colwise preserve rownames(df)

### DIFF
--- a/R/helper-col-wise.r
+++ b/R/helper-col-wise.r
@@ -61,7 +61,7 @@ colwise <- function(.fun, .cols = true) {
     
     df <- as.data.frame(lapply(filtered, .fun, ...))
     names(df) <- names(filtered)
-    if (nrow(df) == length(row.names) && is.character(row.names)) {
+    if (nrow(df) == length(row.names) && !is.na(row.names)) {
       rownames(df) <- row.names
     }
     df


### PR DESCRIPTION
the *colwise functions killed rwonames if any.  this patch makes them preserve the rownames, yet allows to set the rownames explicitely.
