### PR TITLE
Promote .inform to an explicit argument.

### DIFF
--- a/R/ply-array.r
+++ b/R/ply-array.r
@@ -19,13 +19,14 @@
 #' laply(seq_len(10), identity)
 #' laply(seq_len(10), rep, times = 4)
 #' laply(seq_len(10), matrix, nrow = 2, ncol = 2)
-laply <-  function(.data, .fun = NULL, ..., .progress = "none", .drop = TRUE, .parallel = FALSE) {
+laply <-  function(.data, .fun = NULL, ..., .progress = "none", .drop = TRUE, .inform = FALSE, .parallel = FALSE) {
   if (is.character(.fun)) .fun <- do.call("each", as.list(.fun))
   if (!is.function(.fun)) stop(".fun is not a function.")
 
   if (!inherits(.data, "split")) .data <- as.list(.data)
-  res <- llply(.data = .data, .fun = .fun, ...,
-    .progress = .progress, .parallel = .parallel)
+
+  res <- llply(.data = .data, .fun = .fun, ..., 
+    .progress = .progress, .inform = .inform, .parallel = .parallel)
 
   list_to_array(res, attr(.data, "split_labels"), .drop)
 }
@@ -66,12 +67,13 @@ laply <-  function(.data, .fun = NULL, ..., .progress = "none", .drop = TRUE, .p
 #' daply(baseball[, c(2, 6:9)], .(year), colwise(mean))
 #' daply(baseball[, 6:9], .(baseball$year), colwise(mean))
 #' daply(baseball, .(year), function(df) colwise(mean)(df[, 6:9]))
-daply <- function(.data, .variables, .fun = NULL, ..., .progress = "none", .drop_i = TRUE, .drop_o = TRUE, .parallel = FALSE) {
+daply <- function(.data, .variables, .fun = NULL, ..., .progress = "none", .drop_i = TRUE, .drop_o = TRUE, .inform = FALSE, .parallel = FALSE) {
   .variables <- as.quoted(.variables)
   pieces <- splitter_d(.data, .variables, drop = .drop_i)
 
-  laply(.data = pieces, .fun = .fun, ...,
-    .progress = .progress, .drop = .drop_o, .parallel = .parallel)
+  laply(.data = pieces, .fun = .fun, ..., 
+    .progress = .progress, .drop = .drop_o,
+    .inform = .inform, .parallel = .parallel)
 }
 
 #' Split array, apply function, and return results in an array.
@@ -105,9 +107,10 @@ daply <- function(.data, .variables, .fun = NULL, ..., .progress = "none", .drop
 #' aaply(ozone, 1:2, standardise)
 #'
 #' aaply(ozone, 1:2, diff)
-aaply <- function(.data, .margins, .fun = NULL, ..., .expand = TRUE, .progress = "none", .drop = TRUE, .parallel = FALSE) {
+aaply <- function(.data, .margins, .fun = NULL, ..., .expand = TRUE, .progress = "none", .drop = TRUE, .inform = FALSE, .parallel = FALSE) {
   pieces <- splitter_a(.data, .margins, .expand)
-
-  laply(.data = pieces, .fun = .fun, ...,
-    .progress = .progress, .drop = .drop, .parallel = .parallel)
+  
+  laply(.data = pieces, .fun = .fun, ..., 
+    .progress = .progress, .drop = .drop,
+    .inform = .inform, .parallel = .parallel)
 }

--- a/R/ply-data-frame.r
+++ b/R/ply-data-frame.r
@@ -7,11 +7,11 @@
 #' @template l-
 #' @template -d
 #' @export
-ldply <- function(.data, .fun = NULL, ..., .progress = "none", .parallel = FALSE) {
+ldply <- function(.data, .fun = NULL, ..., .progress = "none", .inform = FALSE, .parallel = FALSE) {
   if (!inherits(.data, "split")) .data <- as.list(.data)
-  res <- llply(.data = .data, .fun = .fun, ...,
-    .progress = .progress, .parallel = .parallel)
-
+  res <- llply(.data = .data, .fun = .fun, ..., 
+    .progress = .progress, .inform = .inform, .parallel = .parallel)
+  
   list_to_dataframe(res, attr(.data, "split_labels"))
 }
 
@@ -63,13 +63,13 @@ ldply <- function(.data, .fun = NULL, ..., .progress = "none", .parallel = FALSE
 #' base2 <- ddply(baseball, .(id), transform,
 #'  career_year = year - min(year) + 1
 #' )
-ddply <- function(.data, .variables, .fun = NULL, ..., .progress = "none", .drop = TRUE, .parallel = FALSE) {
+ddply <- function(.data, .variables, .fun = NULL, ..., .progress = "none", .drop = TRUE, .inform = FALSE, .parallel = FALSE) {
   if (empty(.data)) return(.data)
   .variables <- as.quoted(.variables)
   pieces <- splitter_d(.data, .variables, drop = .drop)
-
-  ldply(.data = pieces, .fun = .fun, ...,
-    .progress = .progress, .parallel = .parallel)
+  
+  ldply(.data = pieces, .fun = .fun, ..., 
+    .progress = .progress, .inform = .inform, .parallel = .parallel)
 }
 
 #' Split array, apply function, and return results in a data frame.
@@ -81,9 +81,9 @@ ddply <- function(.data, .variables, .fun = NULL, ..., .progress = "none", .drop
 #' @template a-
 #' @template -d
 #' @export
-adply <- function(.data, .margins, .fun = NULL, ..., .expand = TRUE, .progress = "none", .parallel = FALSE) {
+adply <- function(.data, .margins, .fun = NULL, ..., .expand = TRUE, .progress = "none", .inform = FALSE, .parallel = FALSE) {
   pieces <- splitter_a(.data, .margins, .expand)
-
-  ldply(.data = pieces, .fun = .fun, ...,
-    .progress = .progress, .parallel = .parallel)
+  
+  ldply(.data = pieces, .fun = .fun, ..., 
+    .progress = .progress, .inform = .inform, .parallel = .parallel)
 }

--- a/R/ply-list.r
+++ b/R/ply-list.r
@@ -7,9 +7,6 @@
 #' @template ply
 #' @template l-
 #' @template -l
-#' @param .inform produce informative error messages?  This is turned off by
-#'   by default because it substantially slows processing speed, but is very
-#'   useful for debugging
 #' @export
 #' @examples
 #' llply(llply(mtcars, round), table)
@@ -106,12 +103,12 @@ llply <- function(.data, .fun = NULL, ..., .progress = "none", .inform = FALSE, 
 #' with(coef, plot(`(Intercept)`, year))
 #' qual <- laply(models, function(mod) summary(mod)$r.squared)
 #' hist(qual)
-dlply <- function(.data, .variables, .fun = NULL, ..., .progress = "none", .drop = TRUE, .parallel = FALSE) {
+dlply <- function(.data, .variables, .fun = NULL, ..., .progress = "none", .drop = TRUE, .inform = FALSE, .parallel = FALSE) {
   .variables <- as.quoted(.variables)
   pieces <- splitter_d(.data, .variables, drop = .drop)
-
-  llply(.data = pieces, .fun = .fun, ...,
-    .progress = .progress, .parallel = .parallel)
+  
+  llply(.data = pieces, .fun = .fun, ..., 
+    .progress = .progress, .inform = .inform, .parallel = .parallel)
 }
 
 #' Split array, apply function, and return results in a list.
@@ -127,9 +124,9 @@ dlply <- function(.data, .variables, .fun = NULL, ..., .progress = "none", .drop
 #' @examples
 #' alply(ozone, 3, quantile)
 #' alply(ozone, 3, function(x) table(round(x)))
-alply <- function(.data, .margins, .fun = NULL, ..., .expand = TRUE, .progress = "none", .parallel = FALSE) {
+alply <- function(.data, .margins, .fun = NULL, ..., .expand = TRUE, .progress = "none", .inform = FALSE, .parallel = FALSE) {
   pieces <- splitter_a(.data, .margins, .expand)
-
-  llply(.data = pieces, .fun = .fun, ...,
-    .progress = .progress, .parallel = .parallel)
+  
+  llply(.data = pieces, .fun = .fun, ..., 
+    .progress = .progress, .inform = .inform, .parallel = .parallel)
 }

--- a/man-roxygen/ply.r
+++ b/man-roxygen/ply.r
@@ -1,5 +1,8 @@
 #' @param .fun function to apply to each piece
 #' @param ... other arguments passed on to \code{.fun}
+#' @param .inform produce informative error messages?  This is turned off by
+#'   by default because it substantially slows processing speed, but is very
+#'   useful for debugging
 #' @param .progress name of the progress bar to use, see
 #'   \code{\link{create_progress_bar}}
 #' @keywords manip

--- a/man/aaply.Rd
+++ b/man/aaply.Rd
@@ -3,12 +3,17 @@
 \title{Split array, apply function, and return results in an array.}
 \usage{
   aaply(.data, .margins, .fun = NULL, ..., .expand = TRUE,
-    .progress = "none", .drop = TRUE, .parallel = FALSE)
+    .progress = "none", .drop = TRUE, .inform = FALSE,
+    .parallel = FALSE)
 }
 \arguments{
   \item{.fun}{function to apply to each piece}
 
   \item{...}{other arguments passed on to \code{.fun}}
+
+  \item{.inform}{produce informative error messages?  This
+  is turned off by by default because it substantially
+  slows processing speed, but is very useful for debugging}
 
   \item{.progress}{name of the progress bar to use, see
   \code{\link{create_progress_bar}}}

--- a/man/adply.Rd
+++ b/man/adply.Rd
@@ -3,12 +3,16 @@
 \title{Split array, apply function, and return results in a data frame.}
 \usage{
   adply(.data, .margins, .fun = NULL, ..., .expand = TRUE,
-    .progress = "none", .parallel = FALSE)
+    .progress = "none", .inform = FALSE, .parallel = FALSE)
 }
 \arguments{
   \item{.fun}{function to apply to each piece}
 
   \item{...}{other arguments passed on to \code{.fun}}
+
+  \item{.inform}{produce informative error messages?  This
+  is turned off by by default because it substantially
+  slows processing speed, but is very useful for debugging}
 
   \item{.progress}{name of the progress bar to use, see
   \code{\link{create_progress_bar}}}

--- a/man/alply.Rd
+++ b/man/alply.Rd
@@ -3,12 +3,16 @@
 \title{Split array, apply function, and return results in a list.}
 \usage{
   alply(.data, .margins, .fun = NULL, ..., .expand = TRUE,
-    .progress = "none", .parallel = FALSE)
+    .progress = "none", .inform = FALSE, .parallel = FALSE)
 }
 \arguments{
   \item{.fun}{function to apply to each piece}
 
   \item{...}{other arguments passed on to \code{.fun}}
+
+  \item{.inform}{produce informative error messages?  This
+  is turned off by by default because it substantially
+  slows processing speed, but is very useful for debugging}
 
   \item{.progress}{name of the progress bar to use, see
   \code{\link{create_progress_bar}}}

--- a/man/daply.Rd
+++ b/man/daply.Rd
@@ -4,12 +4,16 @@
 \usage{
   daply(.data, .variables, .fun = NULL, ...,
     .progress = "none", .drop_i = TRUE, .drop_o = TRUE,
-    .parallel = FALSE)
+    .inform = FALSE, .parallel = FALSE)
 }
 \arguments{
   \item{.fun}{function to apply to each piece}
 
   \item{...}{other arguments passed on to \code{.fun}}
+
+  \item{.inform}{produce informative error messages?  This
+  is turned off by by default because it substantially
+  slows processing speed, but is very useful for debugging}
 
   \item{.progress}{name of the progress bar to use, see
   \code{\link{create_progress_bar}}}

--- a/man/ddply.Rd
+++ b/man/ddply.Rd
@@ -3,12 +3,17 @@
 \title{Split data frame, apply function, and return results in a data frame.}
 \usage{
   ddply(.data, .variables, .fun = NULL, ...,
-    .progress = "none", .drop = TRUE, .parallel = FALSE)
+    .progress = "none", .drop = TRUE, .inform = FALSE,
+    .parallel = FALSE)
 }
 \arguments{
   \item{.fun}{function to apply to each piece}
 
   \item{...}{other arguments passed on to \code{.fun}}
+
+  \item{.inform}{produce informative error messages?  This
+  is turned off by by default because it substantially
+  slows processing speed, but is very useful for debugging}
 
   \item{.progress}{name of the progress bar to use, see
   \code{\link{create_progress_bar}}}

--- a/man/dlply.Rd
+++ b/man/dlply.Rd
@@ -3,12 +3,17 @@
 \title{Split data frame, apply function, and return results in a list.}
 \usage{
   dlply(.data, .variables, .fun = NULL, ...,
-    .progress = "none", .drop = TRUE, .parallel = FALSE)
+    .progress = "none", .drop = TRUE, .inform = FALSE,
+    .parallel = FALSE)
 }
 \arguments{
   \item{.fun}{function to apply to each piece}
 
   \item{...}{other arguments passed on to \code{.fun}}
+
+  \item{.inform}{produce informative error messages?  This
+  is turned off by by default because it substantially
+  slows processing speed, but is very useful for debugging}
 
   \item{.progress}{name of the progress bar to use, see
   \code{\link{create_progress_bar}}}

--- a/man/laply.Rd
+++ b/man/laply.Rd
@@ -3,12 +3,16 @@
 \title{Split list, apply function, and return results in an array.}
 \usage{
   laply(.data, .fun = NULL, ..., .progress = "none",
-    .drop = TRUE, .parallel = FALSE)
+    .drop = TRUE, .inform = FALSE, .parallel = FALSE)
 }
 \arguments{
   \item{.fun}{function to apply to each piece}
 
   \item{...}{other arguments passed on to \code{.fun}}
+
+  \item{.inform}{produce informative error messages?  This
+  is turned off by by default because it substantially
+  slows processing speed, but is very useful for debugging}
 
   \item{.progress}{name of the progress bar to use, see
   \code{\link{create_progress_bar}}}

--- a/man/ldply.Rd
+++ b/man/ldply.Rd
@@ -3,12 +3,16 @@
 \title{Split list, apply function, and return results in a data frame.}
 \usage{
   ldply(.data, .fun = NULL, ..., .progress = "none",
-    .parallel = FALSE)
+    .inform = FALSE, .parallel = FALSE)
 }
 \arguments{
   \item{.fun}{function to apply to each piece}
 
   \item{...}{other arguments passed on to \code{.fun}}
+
+  \item{.inform}{produce informative error messages?  This
+  is turned off by by default because it substantially
+  slows processing speed, but is very useful for debugging}
 
   \item{.progress}{name of the progress bar to use, see
   \code{\link{create_progress_bar}}}

--- a/man/llply.Rd
+++ b/man/llply.Rd
@@ -10,6 +10,10 @@
 
   \item{...}{other arguments passed on to \code{.fun}}
 
+  \item{.inform}{produce informative error messages?  This
+  is turned off by by default because it substantially
+  slows processing speed, but is very useful for debugging}
+
   \item{.progress}{name of the progress bar to use, see
   \code{\link{create_progress_bar}}}
 
@@ -17,10 +21,6 @@
 
   \item{.parallel}{if \code{TRUE}, apply function in
   parallel, using parallel backend provided by foreach}
-
-  \item{.inform}{produce informative error messages?  This
-  is turned off by by default because it substantially
-  slows processing speed, but is very useful for debugging}
 }
 \value{
   list of results


### PR DESCRIPTION
For [d|l|a][d|l|a]ply, make the .inform paramter and explicit parameter
to the functions.  Added the documentation for .inform to the ply
documentation template.  Passed the value through to the underlying
plyr function. Re-oxygenized.

Addresses a request from Issue #50.
