### PR TITLE
Fix progress bars reporting inaccurate progress when .parallel=TRUE.

### DIFF
--- a/R/ply-list.r
+++ b/R/ply-list.r
@@ -41,9 +41,9 @@ llply <- function(.data, .fun = NULL, ..., .progress = "none", .inform = FALSE, 
   if (n == 0) return(list())
 
   if ( (!.parallel) || getOption("cores") ) {
-    ncores = 1
+    ncores <- 1
   } else {
-    ncores = getOption("cores")
+    ncores <- getOption("cores")
   }
 
   progress <- create_progress_bar(.progress)


### PR DESCRIPTION
Assumes that the parallel backend was initialized via something like `library(doMC);options(cores=4);registerDoMC()`
