### PR TITLE
First try at fix for scoping issues

### DIFF
--- a/R/ply-data-frame.r
+++ b/R/ply-data-frame.r
@@ -7,10 +7,23 @@
 #' @template l-
 #' @template -d
 #' @export
-ldply <- function(.data, .fun = NULL, ..., .progress = "none", .parallel = FALSE) {
+ldply <- function(.data, .fun = NULL, ..., .progress = "none", .parallel = FALSE,
+  .captured_args = NULL, .captured_env = parent.frame()) {
+
   if (!inherits(.data, "split")) .data <- as.list(.data)
-  res <- llply(.data = .data, .fun = .fun, ...,
-    .progress = .progress, .parallel = .parallel)
+
+  dot_args = match.call(expand.dots = FALSE)$...
+  if (!is.null(dot_args)) {
+    if (!is.null(.captured_args)) {
+      stop("Can't have both .captured_args and ... arguments.")
+    } else {
+      .captured_args = dot_args
+    }
+  }
+
+  res <- llply(.data = .data, .fun = .fun,
+    .progress = .progress, .parallel = .parallel,
+    .captured_args = .captured_args, .captured_env = .captured_env)
 
   list_to_dataframe(res, attr(.data, "split_labels"))
 }
@@ -63,13 +76,23 @@ ldply <- function(.data, .fun = NULL, ..., .progress = "none", .parallel = FALSE
 #' base2 <- ddply(baseball, .(id), transform,
 #'  career_year = year - min(year) + 1
 #' )
-ddply <- function(.data, .variables, .fun = NULL, ..., .progress = "none", .drop = TRUE, .parallel = FALSE) {
+ddply <- function(.data, .variables, .fun = NULL, ..., .progress = "none", .drop = TRUE, .parallel = FALSE,
+  .captured_args = NULL, .captured_env = parent.frame()) {
   if (empty(.data)) return(.data)
   .variables <- as.quoted(.variables)
   pieces <- splitter_d(.data, .variables, drop = .drop)
 
-  ldply(.data = pieces, .fun = .fun, ...,
-    .progress = .progress, .parallel = .parallel)
+  dot_args = match.call(expand.dots = FALSE)$...
+  if (!is.null(dot_args)) {
+    if (!is.null(.captured_args)) {
+      stop("Can't have both .captured_args and ... arguments.")
+    } else {
+      .captured_args = dot_args
+    }
+  }
+
+  ldply(.data = pieces, .fun = .fun, .progress = .progress, .parallel = .parallel,
+    .captured_args = .captured_args, .captured_env = .captured_env)
 }
 
 #' Split array, apply function, and return results in a data frame.


### PR DESCRIPTION
This is an attempt at a fix for #3.

It seems to do the right thing for the example code:

```
# Generate some data
set.seed(321)
myD <- data.frame( 
  Place = sample(c("AWQ","DFR", "WEQ"), 10, replace=T),
  Light = sample(LETTERS[1:2], 15, replace=T),
  value=rnorm(30) 
)

myfunc <- function(xdf, sctype) {
  force(sctype)
  ddply(xdf, .(Place, Light), transform, 
    rng = paste(value, sctype))
}

myfunc(myD, "range")
```

It also fixes the behavior for this question on stackoverflow: http://stackoverflow.com/questions/6955128/object-not-found-error-with-ddply-inside-a-function

Some notes:
- It passes all the tests! (And it could probably use some new ones)
- I don't know how performance is with `do.call` vs. calling the function directly. 
- I've only implemented it for `ddply`, `ldply`, and `llply`.
- It's not implemented for the special "split" case in `llply`.
