### PR TITLE
Fix aaply typo

### DIFF
--- a/R/aaply.r
+++ b/R/aaply.r
@@ -6,7 +6,7 @@
 #' always return an array, and when the function returns >1 d data structures,
 #' those dimensions are added on to the highest dimensions, rather than the
 #' lowest dimensions.  This makes \code{aaply} idempotent, so that
-#' \code{apply(input, X, identity)} is equivalent to \code{aperm(input, X)}.
+#' \code{aaply(input, X, identity)} is equivalent to \code{aperm(input, X)}.
 #'
 #' @template ply
 #' @template a-

--- a/man/aaply.Rd
+++ b/man/aaply.Rd
@@ -60,7 +60,7 @@
   function returns >1 d data structures, those dimensions
   are added on to the highest dimensions, rather than the
   lowest dimensions.  This makes \code{aaply} idempotent,
-  so that \code{apply(input, X, identity)} is equivalent to
+  so that \code{aaply(input, X, identity)} is equivalent to
   \code{aperm(input, X)}.
 }
 \section{Input}{


### PR DESCRIPTION
This fixes a typo where `apply` is written instead of `aaply`.
