### PR TITLE
Fix for reshape2:::dcast segfault - issue 31

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -22,15 +22,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // split_indices
-std::vector<std::vector<int> > split_indices(IntegerVector group, int n = 0);
-RcppExport SEXP plyr_split_indices(SEXP groupSEXP, SEXP nSEXP) {
+std::vector<std::vector<int> > split_indices(IntegerVector group, int groups);
+RcppExport SEXP plyr_split_indices(SEXP groupSEXP, SEXP groupsSEXP) {
 BEGIN_RCPP
     SEXP __sexp_result;
     {
         Rcpp::RNGScope __rngScope;
         Rcpp::traits::input_parameter< IntegerVector >::type group(groupSEXP );
-        Rcpp::traits::input_parameter< int >::type n(nSEXP );
-        std::vector<std::vector<int> > __result = split_indices(group, n);
+        Rcpp::traits::input_parameter< int >::type groups(groupsSEXP );
+        std::vector<std::vector<int> > __result = split_indices(group, groups);
         PROTECT(__sexp_result = Rcpp::wrap(__result));
     }
     UNPROTECT(1);

--- a/src/split-numeric.cpp
+++ b/src/split-numeric.cpp
@@ -16,19 +16,11 @@ using namespace Rcpp;
 //' @examples
 //' split_indices(sample(10, 100, rep = TRUE), 10)
 // [[Rcpp::export]]
-std::vector<std::vector<int> > split_indices(IntegerVector group, int n = 0) {
-  if (n < 0) stop("n must be a positive integer");
-  
-  std::vector<std::vector<int> > ids(n);
-  
-  int nx = group.size();
-  for (int i = 0; i < nx; ++i) {
-    if (group[i] > n) {
-      ids.resize(group[i]);
+std::vector<std::vector<int> > split_indices(IntegerVector group, int groups) {
+    std::vector<std::vector<int> > ids(groups);
+    int n = group.size();
+    for (int i = 0; i < n; ++i) {
+        ids[group[i] - 1].push_back(i + 1);
     }
-    
-    ids[group[i] - 1].push_back(i + 1);
-  }
-  
-  return ids;
+    return ids;
 }


### PR DESCRIPTION
This is a fix for https://github.com/hadley/reshape/issues/31.
Note: I dint write any of this code. 'split-numeric' is written by Hadley and changes to 'RcppExports' are taken from Romain's code from 'dplyr'
