### PR TITLE
`rename()` offers silent/message/warning/error if duplicated names -addresses #127

### DIFF
--- a/R/rename.r
+++ b/R/rename.r
@@ -22,18 +22,18 @@
 rename <- function(x, replace, warn_missing = TRUE, duplicate_behavior = "warning" ) {
   
   # This line does the real work of `rename()`.
-  base::names(x) <- plyr::revalue(base::names(x), replace, warn_missing = warn_missing)
+  names(x) <- revalue(names(x), replace, warn_missing = warn_missing)
   
   # Check if any names are duplicated
-  tabled_values <- base::table(base::names(x))
-  duplicated_names <- base::names(tabled_values[tabled_values>1])
-  if( base::length(duplicated_names) > 0L ) {
-    #     response_message <- base::paste0("The plyr::rename operation has created duplicates for the following names: `", base::paste(duplicated_names, collapse="`, `"), "`")
-    response_message <- base::paste0("The plyr::rename operation has created duplicates for the following name(s): (`", base::paste(duplicated_names, collapse="`, `"), "`)")
-    if( duplicate_behavior == "error") base::stop(response_message)
-    else if( duplicate_behavior == "warning" ) base::warning(response_message)
-    else if( duplicate_behavior == "message" ) base::message(response_message)
-    else if( duplicate_behavior != "silent" ) base::stop("The plyr::rename value passed to the `duplicate_behavior` parameter was not recognized.")
+  tabled_values <- table(names(x))
+  duplicated_names <- names(tabled_values[tabled_values>1])
+  if( length(duplicated_names) > 0L ) {
+    #     response_message <- paste0("The plyr::rename operation has created duplicates for the following names: `", paste(duplicated_names, collapse="`, `"), "`")
+    response_message <- paste0("The plyr::rename operation has created duplicates for the following name(s): (`", paste(duplicated_names, collapse="`, `"), "`)")
+    if( duplicate_behavior == "error") stop(response_message)
+    else if( duplicate_behavior == "warning" ) warning(response_message)
+    else if( duplicate_behavior == "message" ) message(response_message)
+    else if( duplicate_behavior != "silent" ) stop("The plyr::rename value passed to the `duplicate_behavior` parameter was not recognized.")
   }  
   return( x )
 }

--- a/R/rename.r
+++ b/R/rename.r
@@ -24,9 +24,8 @@ rename <- function(x, replace, warn_missing = TRUE, duplicate_behavior = "warnin
   # This line does the real work of `rename()`.
   names(x) <- revalue(names(x), replace, warn_missing = warn_missing)
   
-  # Check if any names are duplicated
-  tabled_values <- table(names(x))
-  duplicated_names <- names(tabled_values[tabled_values>1])
+  # Check if any names are duplicated.
+  duplicated_names <- names(x)[duplicated(names(x))]
   if( length(duplicated_names) > 0L ) {
     #     response_message <- paste0("The plyr::rename operation has created duplicates for the following names: `", paste(duplicated_names, collapse="`, `"), "`")
     response_message <- paste0("The plyr::rename operation has created duplicates for the following name(s): (`", paste(duplicated_names, collapse="`, `"), "`)")

--- a/R/rename.r
+++ b/R/rename.r
@@ -5,6 +5,9 @@
 #'   old names as names.
 #' @param warn_missing print a message if any of the old names are
 #'   not actually present in \code{x}.
+#' @param duplicate_behavior specifies the behavior if duplicates names would result in \code{x}.  
+#' Options are \code{error}, \code{warning}, \code{message}, and \code{silent}.  
+#' The default is \code{warning}.
 #' Note: x is not altered: To save the result, you need to copy the returned
 #'   data into a variable.
 #' @export
@@ -16,7 +19,21 @@
 #' x
 #' # Rename column "disp" to "displacement"
 #' rename(mtcars, c("disp" = "displacement"))
-rename <- function(x, replace, warn_missing = TRUE) {
-  names(x) <- revalue(names(x), replace, warn_missing = warn_missing)
-  x
+rename <- function(x, replace, warn_missing = TRUE, duplicate_behavior = "warning" ) {
+  
+  # This line does the real work of `rename()`.
+  base::names(x) <- plyr::revalue(base::names(x), replace, warn_missing = warn_missing)
+  
+  # Check if any names are duplicated
+  tabled_values <- base::table(base::names(x))
+  duplicated_names <- base::names(tabled_values[tabled_values>1])
+  if( base::length(duplicated_names) > 0L ) {
+    #     response_message <- base::paste0("The plyr::rename operation has created duplicates for the following names: `", base::paste(duplicated_names, collapse="`, `"), "`")
+    response_message <- base::paste0("The plyr::rename operation has created duplicates for the following name(s): (`", base::paste(duplicated_names, collapse="`, `"), "`)")
+    if( duplicate_behavior == "error") base::stop(response_message)
+    else if( duplicate_behavior == "warning" ) base::warning(response_message)
+    else if( duplicate_behavior == "message" ) base::message(response_message)
+    else if( duplicate_behavior != "silent" ) base::stop("The plyr::rename value passed to the `duplicate_behavior` parameter was not recognized.")
+  }  
+  return( x )
 }

--- a/inst/tests/test-rename.r
+++ b/inst/tests/test-rename.r
@@ -1,9 +1,12 @@
-context("Rename")
+#################################################
+### Main-stream cases
+#################################################
+context("Rename - Expected Usage")
 
 test_that("No match leaves names unchanged", {
   x <- c(a = 1, b = 2, c = 3, 4)
   y <- rename(x, c(d = "e"), warn_missing = FALSE)
-
+  
   expect_equal(names(x), names(y))
 })
 
@@ -16,14 +19,14 @@ test_that("Missing old values result in message", {
 test_that("Single name match makes change", {
   x <- c(a = 1, b = 2)
   y <- rename(x, c(b = "c"))
-
+  
   expect_equal(names(y), c("a", "c"))
 })
 
 test_that("Multiple names correctly changed", {
   x <- c(a = 1, b = 2, c = 3)
   y <- rename(x, c("c" = "f", "b" = "e", "a" = "d"))
-
+  
   expect_equal(names(y), c("d", "e", "f"))
 })
 
@@ -36,4 +39,90 @@ test_that("Renaming lists", {
   x <- list(a = 1, b = 2, c = 3)
   y <- rename(x, c("c" = "f", "b" = "e", "a" = "d"))
   expect_identical(y, list(d = 1, e = 2, f = 3))
+})
+
+#################################################
+### Duplicate Names
+#################################################
+context("Rename - Duplicates")
+
+##
+## This batch tests the typical renaming scenarios
+##
+test_that("Renaming list with an conflicting variable name - default", {
+  x <- list(a = 1, b = 2, c = 3)
+  replace_list <- c("c" = "f", "b" = "e", "a" = "f")
+  expected_response <- "The plyr::rename operation has created duplicates for the following name\\(s\\): \\(`f`\\)"
+  expect_warning(object = rename(x=x, replace=replace_list), regexp=expected_response)
+})
+test_that("Renaming list with an conflicting variable name - error", {
+  duplicate_behavior <- "error"
+  x <- list(a = 1, b = 2, c = 3)
+  replace_list <- c("c" = "f", "b" = "e", "a" = "f")
+  expected_response <- "The plyr::rename operation has created duplicates for the following name\\(s\\): \\(`f`\\)"
+  expect_error(object = rename(x=x, replace=replace_list, duplicate_behavior=duplicate_behavior), regexp=expected_response)
+})
+test_that("Renaming list with an conflicting variable name - warning", {
+  duplicate_behavior <- "warning"
+  x <- list(a = 1, b = 2, c = 3)
+  replace_list <- c("c" = "f", "b" = "e", "a" = "f")
+  expected_response <- "The plyr::rename operation has created duplicates for the following name\\(s\\): \\(`f`\\)"
+  expect_warning(object = rename(x=x, replace=replace_list, duplicate_behavior=duplicate_behavior), regexp=expected_response)
+})
+test_that("Renaming list with an conflicting variable name - message", {
+  duplicate_behavior <- "message"
+  x <- list(a = 1, b = 2, c = 3)
+  replace_list <- c("c" = "f", "b" = "e", "a" = "f")
+  expected_response <- "The plyr::rename operation has created duplicates for the following name\\(s\\): \\(`f`\\)"
+  expect_message(object = rename(x=x, replace=replace_list, duplicate_behavior=duplicate_behavior), regexp=expected_response)
+})
+test_that("Renaming list with an conflicting variable name - silent", {
+  duplicate_behavior <- "silent"
+  x <- list(a = 1, b = 2, c = 3)
+  replace_list <- c("c" = "f", "b" = "e", "a" = "f")
+  expected_value <- list(f = 1, e = 2, f = 3)
+  expect_identical(rename(x=x, replace=replace_list, duplicate_behavior=duplicate_behavior), expected=expected_value)
+})
+
+
+##
+## This batch tests the boundary cases
+##
+test_that("Renaming to the same value", {
+  #One element is renamed to itself
+  x <- list(a = 1, b = 2, c = 3)
+  replace_list <- c("a" = "a")
+  expected_value <- x
+  expect_identical(rename(x=x, replace=replace_list), expected=expected_value)
+})
+test_that("Renaming list with an empty renaming vector", {
+  #No renames are requested (which could happen if the calling code was under a lot of automated code.)
+  x <- list(a = 1, b = 2, c = 3)
+  replace_list <- c()
+  expected_value <- x
+  expect_identical(rename(x=x, replace=replace_list), expected=expected_value)
+})
+test_that("Single Swapping (shouldn't cause problems)", {
+  #Notice how a becomes c, while c becomes f.
+  x <- list(a = 1, b = 2, c = 3)
+  replace_list <- c("c" = "f", "b" = "e", "a" = "c")
+  expected_value <- list(c = 1, e = 2, f = 3)
+  actual_value <- rename(x=x, replace=replace_list)
+  expect_identical(actual_value, expected=expected_value)
+})
+test_that("Double Swapping (shouldn't cause problems)", {
+  #Notice how a becomes c, while c becomes a.
+  x <- list(a = 1, b = 2, c = 3)
+  replace_list <- c("c" = "a", "b" = "z", "a" = "c")
+  expected_value <- list(c = 1, z = 2, a = 3)
+  actual_value <- rename(x=x, replace=replace_list)
+  expect_identical(actual_value, expected=expected_value)
+})
+test_that("Multiple assignments for the same element", {
+  #Notice how it requests to change a to d, e, and f.
+  x <- list(a = 1, b = 2, c = 3)
+  replace_list <- c("a" = "d", "a" = "e", "a" = "f")
+  expected_response <- "The following `from` values were not present in `x`: a, a"
+  expected_value <- list(a = 1, a = 2, a = 3)
+  expect_message(rename(x=x, replace=replace_list), regexp=expected_response)
 })

--- a/man/rename.Rd
+++ b/man/rename.Rd
@@ -2,7 +2,7 @@
 \alias{rename}
 \title{Modify names by name, not position.}
 \usage{
-rename(x, replace, warn_missing = TRUE)
+rename(x, replace, warn_missing = TRUE, duplicate_behavior = "warning")
 }
 \arguments{
   \item{x}{named object to modify}
@@ -11,7 +11,12 @@ rename(x, replace, warn_missing = TRUE)
   values, and old names as names.}
 
   \item{warn_missing}{print a message if any of the old
-  names are not actually present in \code{x}. Note: x is
+  names are not actually present in \code{x}.}
+
+  \item{duplicate_behavior}{specifies the behavior if
+  duplicates names would result in \code{x}. Options are
+  \code{error}, \code{warning}, \code{message}, and
+  \code{silent}. The default is \code{warning}. Note: x is
   not altered: To save the result, you need to copy the
   returned data into a variable.}
 }


### PR DESCRIPTION
`rename()` produces error/warning/message/silent of duplicate names would result 

Avoids the extra commits of https://github.com/hadley/plyr/pull/186

Are you maintaining both NEWS and NEWS.md?