### PR TITLE
.n column in result of rdply is numeric again

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * New parameter `.id` to `ldply()` and `rdply()` that specifies the name of the 
   index column. (Thanks to Kirill Müller, #107, #140, #142)
 
-* The .id column in `ldply()` and `rdply()` is generated as a factor to preserve
+* The .id column in `ldply()` is generated as a factor to preserve
   the sort order, but only if the new `.id` parameter is set. (Thanks to Kirill
   Müller, #137)
 

--- a/R/rdply.r
+++ b/R/rdply.r
@@ -32,9 +32,7 @@ rdply <- function(.n, .expr, .progress = "none", .id = NA) {
                        eval.parent(substitute(function() .expr)))
   names(res) <- seq_len(.n)
   labels <- data.frame(.n = seq_len(.n))
-  if (!is.na(.id)) {
-    labels$.n <- factor(labels$.n, levels = labels$.n)
+  if (!is.na(.id))
     names(labels) <- .id
-  }
   list_to_dataframe(res, labels)
 }

--- a/inst/tests/test-rply.r
+++ b/inst/tests/test-rply.r
@@ -142,5 +142,5 @@ test_that("Invalid arguments for r_ply", {
 
 test_that(".id column for rdply", {
   expect_equal(rdply(5, 10)$.n, 1:5)
-  expect_equal(rdply(5, 10, .id=".n")$.n, factor(1:5))
+  expect_equal(rdply(5, 10, .id=".x")$.x, 1:5)
 })


### PR DESCRIPTION
Tests had to be altered, because this was actually the behavior of plyr 1.8.

Fixes #199.
