### PR TITLE
Handle `.id = NULL` in `ldply`

### DIFF
--- a/R/ldply.r
+++ b/R/ldply.r
@@ -18,15 +18,10 @@ ldply <- function(.data, .fun = NULL, ..., .progress = "none", .inform = FALSE,
     .progress = .progress, .inform = .inform,
     .parallel = .parallel, .paropts = .paropts)
 
-  drop_.id <- is.null(.id)
-  if (is.null(.id) || is.na(.id)) {
+  if (!is.null(.id) && is.na(.id)) {
     .id <- ".id"
     id_as_factor <- FALSE
   } else
     id_as_factor <- TRUE
-  df <- list_to_dataframe(res, attr(.data, "split_labels"), .id, id_as_factor)
-  if (drop_.id){
-    df$.id <- NULL
-  }
-  return(df)
+  list_to_dataframe(res, attr(.data, "split_labels"), .id, id_as_factor)
 }

--- a/R/ldply.r
+++ b/R/ldply.r
@@ -18,10 +18,15 @@ ldply <- function(.data, .fun = NULL, ..., .progress = "none", .inform = FALSE,
     .progress = .progress, .inform = .inform,
     .parallel = .parallel, .paropts = .paropts)
 
-  if (is.na(.id)) {
+  drop_.id <- is.null(.id)
+  if (is.null(.id) || is.na(.id)) {
     .id <- ".id"
     id_as_factor <- FALSE
   } else
     id_as_factor <- TRUE
-  list_to_dataframe(res, attr(.data, "split_labels"), .id, id_as_factor)
+  df <- list_to_dataframe(res, attr(.data, "split_labels"), .id, id_as_factor)
+  if (drop_.id){
+    df$.id <- NULL
+  }
+  return(df)
 }

--- a/inst/tests/test-data-frame.r
+++ b/inst/tests/test-data-frame.r
@@ -62,14 +62,16 @@ test_that("label variables always preserved", {
 })
 
 # Test for #140
-test_that(".id column can be renamed", {
+test_that(".id column can be renamed or dropped", {
   l <- llply(1:4, function(i) rep(i, i))
   names(l) <- 1:4
   f <- function(l) data.frame(sum=sum(unlist(l)))
   
   out1 <- ldply(l, f)
   out2 <- ldply(l, f, .id='x')
+  out3 <- ldply(l, f, .id=NULL)
   
   expect_equal(names(out1), c('.id', 'sum'))
   expect_equal(names(out2), c('x', 'sum'))
+  expect_equal(names(out3), c('sum'))
 })


### PR DESCRIPTION
Per the documentation, of `@param .id`, `NULL` should work as follows: "Pass \code{NULL} to avoid creation of the index column." These changes handle the `NULL` here, though I am sure something in `list_to_dataframe` could work as well. This was the easiest without getting too deep into the guts of the code.

As an aside, the `is.na(.id)` on line 22 gives warning if you pass `NULL`, so I wrote this to check `NULL` first for the short-circuit, and hence no warning. So, if you don't like the way I implemented this, you would want to still do something about that warning because it should not come up.