### PR TITLE
Fix for problem with aaply in plyr >= 1.8.0

### DIFF
--- a/R/list-to-array.r
+++ b/R/list-to-array.r
@@ -12,7 +12,10 @@ list_to_array <- function(res, labels = NULL, .drop = FALSE) {
   n <- length(res)
 
   atomic <- sapply(res, is.atomic)
-  if (all(atomic) || all(!atomic)) {
+  is_array <- !is.null(attributes(res)) && attr(res, "split_type") == "array"
+  if(! (all(atomic) || all(!atomic)) )
+    stop("Results must have compatible types.")
+  if (all(atomic) || is.list(res) && ! is_array) {
     dlength <- unique.default(llply(res, dims))
     if (length(dlength) != 1)
       stop("Results must have the same number of dimensions.")
@@ -33,9 +36,14 @@ list_to_array <- function(res, labels = NULL, .drop = FALSE) {
 
     res <- unlist(res, use.names = FALSE, recursive = FALSE)
   } else {
-    stop("Results must have compatible types.")
+    res_index <- as.data.frame(matrix(0, 1, 0))
+    res_dim <- numeric()
+    res_labels <- NULL
+    attr(res, "split_type") <- NULL
+    attr(res, "split_labels") <- NULL
+    class(res) <- class(res)[2]
   }
-
+         
   if (is.null(labels)) {
     labels <- data.frame(X = seq_len(n))
     in_labels <- list(NULL)

--- a/tests/testthat/test-array.r
+++ b/tests/testthat/test-array.r
@@ -154,6 +154,28 @@ test_that("array reconstruction correct with missing cells", {
   expect_that(da, equals(m, check.attributes = FALSE))
 })
 
+test_that("aaply produces list array output when function outputs list", {
+  set.seed(1234)
+  # two random arrays, one 2D (i.e. a matrix) the other 3D
+  # they contain fake linear data with noise, the first
+  # with each row a set of data, the second with the first
+  # two dimensions each indexing a vector in the third dimension
+  array1 <- lapply(1:5, function(x) 1:5 + 0.5*rnorm(1:5))
+  array1 <- do.call("rbind", array1)
+  array2 <- lapply(1:25, function(x) 1:5 + 0.5*rnorm(1:5))
+  array2 <- unlist(array2)
+  dim(array2) <- c(5,5,5)
+  # like the 'ozone' dataset
+  array2 <- aperm(array2, c(2,3,1))
+
+  modFn <- function(vec) lm(y ~ x, data = data.frame(x = 1:5, y = vec))
+  
+  # tryCatch-like semantics
+  # (http://stackoverflow.com/questions/10826365/how-to-test-that-an-error-does-not-occur)
+  expect_true({mod1 <- aaply(array1, 1, modFn); TRUE})
+  expect_true({mod2 <- aaply(array2, 1:2, modFn); TRUE})
+})
+
 
 set_dimnames <- function(x, nm) {
   dimnames(x) <- nm


### PR DESCRIPTION
## Problem running code from the J Stat Soft paper

When attempting to try out the examples from the [J Stat Soft](https://www.jstatsoft.org/article/view/v040i01) paper on plyr ("split-apply-combine" paradigm), the first examples with aaply and the ozone dataset failed.

I went back and rebuilt R from September 2009, and plyr from 2009, and tested the code as described in the paper and it all worked.  I then went through the various versions of plyr/R until the aaply code broke, which happened at plyr-1.8.0 (it is still broken when tested on the latest code from github).

After forking the plyr git repository, I have fixed the issue so that the ozone examples now work 
(without breaking the other 'testthat' tests).

Specifically, the changes are
- Added a new unit test to check that aaply works with an array list object
- Fixed the list_to_array code called by laply to correctly check whether or not the 'res' object (from llply) is from an array list, and deal with it appropriately.
- Checked that the new tests worked with the modified code, and that no other tests failed as a result of the new code.

Best 
Rob Pollock.
