### PR TITLE
Parallel execution in raply, rdply, rlply

### DIFF
--- a/R/raply.r
+++ b/R/raply.r
@@ -14,6 +14,14 @@
 #' @param .progress name of the progress bar to use, see \code{\link{create_progress_bar}}
 #' @return if results are atomic with same type and dimensionality, a vector, matrix or array; otherwise, a list-array (a list with dimensions)
 #' @param .drop should extra dimensions of length 1 be dropped, simplifying the output.  Defaults to \code{TRUE}
+#' @param .parallel if \code{TRUE}, apply function in parallel, using parallel
+#'   backend provided by foreach
+#' @param .paropts a list of additional options passed into
+#'   the \code{\link[foreach]{foreach}} function when parallel computation
+#'   is enabled.  This is important if (for example) your code relies on
+#'   external data or packages: use the \code{.export} and \code{.packages}
+#'   arguments to supply them so that all cluster nodes have the correct
+#'   environment set up for computing.
 #' @export
 #' @references Hadley Wickham (2011). The Split-Apply-Combine Strategy for
 #'   Data Analysis. Journal of Statistical Software, 40(1), 1-29.
@@ -29,8 +37,10 @@
 #' hist(raply(1000, mean(rexp(10))))
 #' hist(raply(1000, mean(rexp(100))))
 #' hist(raply(1000, mean(rexp(1000))))
-raply <- function(.n, .expr, .progress = "none", .drop = TRUE) {
+raply <- function(.n, .expr, .progress = "none", .drop = TRUE,
+                  .parallel = FALSE, .paropts = NULL) {
   res <- .rlply_worker(.n, .progress,
-                       eval.parent(substitute(function() .expr)))
+                       eval.parent(substitute(function() .expr)),
+                       .parallel = .parallel, .paropts = .paropts)
   list_to_array(res, NULL, .drop)
 }

--- a/R/rdply.r
+++ b/R/rdply.r
@@ -17,6 +17,14 @@
 #' @param .id name of the index column. Pass \code{NULL} to avoid creation of
 #'   the index column. For compatibility, omit this argument or pass \code{NA}
 #'   to use \code{".n"} as column name.
+#' @param .parallel if \code{TRUE}, apply function in parallel, using parallel
+#'   backend provided by foreach
+#' @param .paropts a list of additional options passed into
+#'   the \code{\link[foreach]{foreach}} function when parallel computation
+#'   is enabled.  This is important if (for example) your code relies on
+#'   external data or packages: use the \code{.export} and \code{.packages}
+#'   arguments to supply them so that all cluster nodes have the correct
+#'   environment set up for computing.
 #' @return a data frame
 #' @export
 #' @references Hadley Wickham (2011). The Split-Apply-Combine Strategy for Data
@@ -26,9 +34,11 @@
 #' rdply(20, mean(runif(100)))
 #' rdply(20, each(mean, var)(runif(100)))
 #' rdply(20, data.frame(x = runif(2)))
-rdply <- function(.n, .expr, .progress = "none", .id = NA) {
+rdply <- function(.n, .expr, .progress = "none", .id = NA,
+                  .parallel = FALSE, .paropts = NULL) {
   res <- .rlply_worker(.n, .progress,
-                       eval.parent(substitute(function() .expr)))
+                       eval.parent(substitute(function() .expr)),
+                       .parallel = .parallel, .paropts = .paropts)
   names(res) <- seq_len(.n)
   if (is.null(.id)) {
       labels <- NULL

--- a/R/rlply.r
+++ b/R/rlply.r
@@ -12,6 +12,14 @@
 #' @param .n number of times to evaluate the expression
 #' @param .expr expression to evaluate
 #' @param .progress name of the progress bar to use, see \code{\link{create_progress_bar}}
+#' @param .parallel if \code{TRUE}, apply function in parallel, using parallel
+#'   backend provided by foreach
+#' @param .paropts a list of additional options passed into
+#'   the \code{\link[foreach]{foreach}} function when parallel computation
+#'   is enabled.  This is important if (for example) your code relies on
+#'   external data or packages: use the \code{.export} and \code{.packages}
+#'   arguments to supply them so that all cluster nodes have the correct
+#'   environment set up for computing.
 #' @return list of results
 #' @export
 #' @references Hadley Wickham (2011). The Split-Apply-Combine Strategy for

--- a/man/raply.Rd
+++ b/man/raply.Rd
@@ -4,7 +4,8 @@
 \alias{raply}
 \title{Replicate expression and return results in a array.}
 \usage{
-raply(.n, .expr, .progress = "none", .drop = TRUE)
+raply(.n, .expr, .progress = "none", .drop = TRUE, .parallel = FALSE,
+  .paropts = NULL)
 }
 \arguments{
 \item{.n}{number of times to evaluate the expression}
@@ -14,6 +15,16 @@ raply(.n, .expr, .progress = "none", .drop = TRUE)
 \item{.progress}{name of the progress bar to use, see \code{\link{create_progress_bar}}}
 
 \item{.drop}{should extra dimensions of length 1 be dropped, simplifying the output.  Defaults to \code{TRUE}}
+
+\item{.parallel}{if \code{TRUE}, apply function in parallel, using parallel
+backend provided by foreach}
+
+\item{.paropts}{a list of additional options passed into
+the \code{\link[foreach]{foreach}} function when parallel computation
+is enabled.  This is important if (for example) your code relies on
+external data or packages: use the \code{.export} and \code{.packages}
+arguments to supply them so that all cluster nodes have the correct
+environment set up for computing.}
 }
 \value{
 if results are atomic with same type and dimensionality, a vector, matrix or array; otherwise, a list-array (a list with dimensions)

--- a/man/rdply.Rd
+++ b/man/rdply.Rd
@@ -4,7 +4,8 @@
 \alias{rdply}
 \title{Replicate expression and return results in a data frame.}
 \usage{
-rdply(.n, .expr, .progress = "none", .id = NA)
+rdply(.n, .expr, .progress = "none", .id = NA, .parallel = FALSE,
+  .paropts = NULL)
 }
 \arguments{
 \item{.n}{number of times to evaluate the expression}
@@ -17,6 +18,16 @@ rdply(.n, .expr, .progress = "none", .id = NA)
 \item{.id}{name of the index column. Pass \code{NULL} to avoid creation of
 the index column. For compatibility, omit this argument or pass \code{NA}
 to use \code{".n"} as column name.}
+
+\item{.parallel}{if \code{TRUE}, apply function in parallel, using parallel
+backend provided by foreach}
+
+\item{.paropts}{a list of additional options passed into
+the \code{\link[foreach]{foreach}} function when parallel computation
+is enabled.  This is important if (for example) your code relies on
+external data or packages: use the \code{.export} and \code{.packages}
+arguments to supply them so that all cluster nodes have the correct
+environment set up for computing.}
 }
 \value{
 a data frame

--- a/man/rlply.Rd
+++ b/man/rlply.Rd
@@ -4,7 +4,7 @@
 \alias{rlply}
 \title{Replicate expression and return results in a list.}
 \usage{
-rlply(.n, .expr, .progress = "none")
+rlply(.n, .expr, .progress = "none", .parallel = FALSE, .paropts = NULL)
 }
 \arguments{
 \item{.n}{number of times to evaluate the expression}
@@ -12,6 +12,16 @@ rlply(.n, .expr, .progress = "none")
 \item{.expr}{expression to evaluate}
 
 \item{.progress}{name of the progress bar to use, see \code{\link{create_progress_bar}}}
+
+\item{.parallel}{if \code{TRUE}, apply function in parallel, using parallel
+backend provided by foreach}
+
+\item{.paropts}{a list of additional options passed into
+the \code{\link[foreach]{foreach}} function when parallel computation
+is enabled.  This is important if (for example) your code relies on
+external data or packages: use the \code{.export} and \code{.packages}
+arguments to supply them so that all cluster nodes have the correct
+environment set up for computing.}
 }
 \value{
 list of results


### PR DESCRIPTION
Having parallel execution in r*ply (as in the other *ply functions) would be tremendously useful for simulation-based research that simply needs to execute the same code over and over, as opposed to iterating over a range of parameters. I mirrored the foreach implementation in llply().
