### PR TITLE
FIX: Keep .progress="progressr" even when .parallel=TRUE

### DIFF
--- a/R/l_ply.r
+++ b/R/l_ply.r
@@ -19,7 +19,7 @@ l_ply <- function(.data, .fun = NULL, ..., .progress = "none", .inform = FALSE,
   n <- length(pieces)
   if (n == 0) return(invisible())
 
-  if (.parallel && !identical(.progress, "none")) {
+  if (.parallel && !identical(.progress, "none") && !identical(.progress, "progressr")) {
     message("Progress disabled when using parallel plyr")
     .progress <- "none"
   }

--- a/R/llply.r
+++ b/R/llply.r
@@ -39,7 +39,7 @@ llply <- function(.data, .fun = NULL, ..., .progress = "none", .inform = FALSE,
   n <- length(pieces)
   if (n == 0) return(list())
 
-  if (.parallel && !identical(.progress, "none")) {
+  if (.parallel && !identical(.progress, "none") && !identical(.progress, "progressr")) {
     message("Progress disabled when using parallel plyr")
     .progress <- "none"
   }


### PR DESCRIPTION
I'm aware that **plyr** is deprecated and AFAIU will only be kept on life support. 

However, if there's the slightest chance I can catch you in a weak moment, this teeny PR makes **dplyr** report on progress also when `.parallel = TRUE`. For this to work, one needs to use **doFuture** for parallel processing and **progressr** for progress managing (any progress reporter can be used, e.g. **progress**).  The only thing that prevents this to work out of the box is that **plyr** 1.8.6 forces `.progress = "none"` whenever `.parallel = TRUE`; this PR allows `.progress = "progressr"` through.

Example of `progress::progress_bar()` updates when running in parallel:

```r
>library(plyr)
> library(progressr)
> doFuture::registerDoFuture()
> future::plan("multisession", workers = 2L)
> handlers("progress")  ## 'progress' package

> with_progress({
+   y <- llply(1:10, function(x) { Sys.sleep(1); identity(x) },
+                 .parallel = TRUE, .progress = "progressr")
+ })
[================>---------------------------------------]  20%
```

Even if this PR never makes it in, I'll leave it here for future references, e.g. in case someone else revives this package.