### PR TITLE
Avoid length check errors

### DIFF
--- a/R/llply.r
+++ b/R/llply.r
@@ -27,7 +27,7 @@ llply <- function(.data, .fun = NULL, ..., .progress = "none", .inform = FALSE,
     pieces <- as.list(.data)
 
     # This special case can be done much faster with lapply, so do it.
-    fast_path <- .progress == "none" && !.inform && !.parallel
+    fast_path <- length(.progress) == 1 && .progress == "none" && !.inform && !.parallel
     if (fast_path) {
       return(structure(lapply(pieces, .fun, ...), dim = dim(pieces)))
     }


### PR DESCRIPTION
The `llply` function doesn't accept a `.progress` argument other than names when the environment variables `_R_CHECK_LENGTH_1_LOGIC2_` is set (to a true-ish value). See [R Internals](https://cran.r-project.org/doc/manuals/r-devel/R-ints.html).  This environment variables is apparently now set by Bioconductor.

If you supply the output of one of the progress_* function, `llply` fails with an error.

Steps to reproduce: 

    Sys.setenv(`_R_CHECK_LENGTH_1_LOGIC2_`="true")

    library(plyr)
    x <- list(a = 1:10, beta = exp(-3:3), logic = c(TRUE,FALSE,FALSE,TRUE))
    llply(x, mean, .progress=progress_text())

Yields the following error message: 

    Error in .progress == "none" && !.inform : 
      'length(x) = 3 > 1' in coercion to 'logical(1)'

Other plyr functions are unaffected and the progress_* functions work fine even with `_R_CHECK_LENGTH_1_LOGIC2_`  set.

This PR fixes the bug by first checking if .progress is of length 1.

