### PR TITLE
more careful test for .progress=="none"

### DIFF
--- a/R/llply.r
+++ b/R/llply.r
@@ -22,12 +22,13 @@ llply <- function(.data, .fun = NULL, ..., .progress = "none", .inform = FALSE,
   if (is.null(.fun)) return(as.list(.data))
   if (is.character(.fun) || is.list(.fun)) .fun <- each(.fun)
   if (!is.function(.fun)) stop(".fun is not a function.")
+  no_progress <- length(.progress) == 1L && .progress == "none"
 
   if (!inherits(.data, "split")) {
     pieces <- as.list(.data)
 
     # This special case can be done much faster with lapply, so do it.
-    fast_path <- .progress == "none" && !.inform && !.parallel
+    fast_path <- no_progress && !.inform && !.parallel
     if (fast_path) {
       return(structure(lapply(pieces, .fun, ...), dim = dim(pieces)))
     }
@@ -39,7 +40,7 @@ llply <- function(.data, .fun = NULL, ..., .progress = "none", .inform = FALSE,
   n <- length(pieces)
   if (n == 0) return(list())
 
-  if (.parallel && .progress != "none") {
+  if (.parallel && !no_progress) {
     message("Progress disabled when using parallel plyr")
     .progress <- "none"
   }


### PR DESCRIPTION
This was causing an error in the simr package when we turn on `_R_CHECK_LENGTH_1_LOGIC2_=true` because the package relies on `check_progress_bar` returning its non-character argument:

https://github.com/pitakakariki/simr/blob/413bcbeb879263f94b0093ffe3793951e32d2d0e/R/maybe.R#L86

this results in the `.progress == "none"` test failing since `length(.progress) > 1`