### PR TITLE
correct error message; also work when is.atomic(NULL) is false.

### DIFF
--- a/R/revalue.r
+++ b/R/revalue.r
@@ -69,8 +69,7 @@ mapvalues <- function(x, from, to, warn_missing = TRUE) {
   if (length(from) != length(to)) {
     stop("`from` and `to` vectors are not the same length.")
   }
-  if (!is.atomic(x)) {
-   if(!is.null(x))
+  if (!is.atomic(x) && !is.null(x)) {
     stop("`x` must be an atomic vector or NULL.")
   }
 

--- a/R/revalue.r
+++ b/R/revalue.r
@@ -70,7 +70,8 @@ mapvalues <- function(x, from, to, warn_missing = TRUE) {
     stop("`from` and `to` vectors are not the same length.")
   }
   if (!is.atomic(x)) {
-    stop("`x` must be an atomic vector.")
+   if(!is.null(x))
+    stop("`x` must be an atomic vector or NULL.")
   }
 
   if (is.factor(x)) {


### PR DESCRIPTION
We are looking into tweaking `is.atomic()` to become faithful to its name and hence give FALSE for NULL.
This would make `plyr` not pass all its test, and the propose PR fixes that ..
notably it fixes the error message anyway, as indeed `NULL` args *have* been allowed.