### PR TITLE
`aaply()` gives error when called with vector with comment attribute

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# plyr (development version)
+# plyr 1.8.8
+
+* Breaks my package
+* Issues reporting disabled on GitHub
+* This version is ahead of GitHub main branch and I can't find it anywhere
 
 # plyr 1.8.7
 


### PR DESCRIPTION
This is not a proper pull request but a work-around for the missing issue tracker.

To reproduce the error:
```
a <- 1:3
comment(a) <- "test"
b <- 2:4
aaply(vec, 1, function(x)  b < x)
```
This gives: "Error in splitter_a(.data, .margins, .expand) : Invalid margin"